### PR TITLE
Make `character_class` the default sort ordering for character grouping

### DIFF
--- a/vue/src/components/Characters/CharacterList.vue
+++ b/vue/src/components/Characters/CharacterList.vue
@@ -112,7 +112,7 @@ export default {
       type: String,
     },
     order: {
-      default: "-class_probability",
+      default: "character_class",
       type: String,
     },
     page_range: {

--- a/vue/src/components/Menus/CharacterOrderingSelect.vue
+++ b/vue/src/components/Menus/CharacterOrderingSelect.vue
@@ -10,7 +10,7 @@ export default {
   props: {
     value: {
       type: String,
-      default: "-class_probability",
+      default: "character_class",
     },
   },
   data() {


### PR DESCRIPTION
Make `character_class` the default sort ordering for character grouping on both the search page and the detail page (if landing directly).