### PR TITLE
Fix display label in case of sourcing by printer

### DIFF
--- a/vue/src/components/Menus/Autocomplete.vue
+++ b/vue/src/components/Menus/Autocomplete.vue
@@ -4,7 +4,7 @@
       size="sm"
       :data="results"
       :value="value"
-      :serializer="serializer"
+      :serializer="displayLabel"
       :placeholder="placeholder"
       @hit="selected=$event"
       @input="search_text=$event"
@@ -41,9 +41,9 @@ export default {
       type: String,
       default: null
     },
-    display_field: {
-      type: String,
-      default: "label"
+    displayLabel: {
+      type: Function,
+      default: null
     },
     n_choices: {
       type: String,
@@ -75,8 +75,6 @@ export default {
           if (results.data.count > 0) {
             this.results = results.data.results;
           } else {
-            var empty_result = {};
-            empty_result[this.display_field] = "No results";
             this.results.push();
           }
         },
@@ -85,19 +83,6 @@ export default {
         }
       );
     }, AUTOCOMPLETE_DEBOUNCE_TIME),
-    serializer: function(x) {
-      if (!!this.prefix_field) {
-        return (
-          this.prefix_field +
-          " " +
-          x[this.prefix_field] +
-          ": " +
-          x[this.display_field]
-        );
-      } else {
-        return x[this.display_field];
-      }
-    },
     clear() {
       this.results = [];
       this.search_text = "";

--- a/vue/src/components/Menus/BookAutocomplete.vue
+++ b/vue/src/components/Menus/BookAutocomplete.vue
@@ -1,16 +1,15 @@
 <template>
   <Autocomplete
-    :value="value"
-    endpoint="/books/"
-    :query_field="bookSearchField[field].query"
-    :label="bookSearchField[field].label"
-    description="Begin typing for suggestions"
-    :display_field="bookSearchField[field].displayField"
-    n_choices="10"
-    return_field="id"
-    prefix_field="vid"
-    @input="$emit('input', $event)"
-    :additional_params="{ characters: true }"
+      :value="value"
+      endpoint="/books/"
+      :query_field="queryField"
+      :label="label"
+      description="Begin typing for suggestions"
+      :displayLabel="displayLabel"
+      n_choices="10"
+      return_field="id"
+      @input="fireInputEvent($event)"
+      :additional_params="{ characters: true }"
   />
 </template>
 
@@ -20,12 +19,10 @@ import Autocomplete from "./Autocomplete";
 const BookSearchField = Object.freeze({
   pq_title: {
     query: 'pq_title',
-    displayField: 'pq_title',
     label: 'Source book by title',
   },
   printer_name: {
     query: 'printer_like',
-    displayField: 'printer_like',
     label: 'Source book by printer name',
   }
 })
@@ -45,9 +42,35 @@ export default {
       default: null,
     },
   },
-  data: function() {
+  computed: {
+    label() {
+      return this.bookSearchField[this.field].label
+    },
+    queryField() {
+      return this.bookSearchField[this.field].query
+    },
+  },
+  methods: {
+    displayLabel(book) {
+      const bookTitle = book['pq_title']
+      if (this.field === 'pq_title') {
+        return this.addPrefixToLabel(book, bookTitle)
+      }
+      const printerName = book['pp_printer'] || book['colloq_printer']
+      return this.addPrefixToLabel(book, `${printerName} - ${bookTitle}`)
+    },
+    fireInputEvent(bookId) {
+      this.$emit('input', bookId)
+    },
+    addPrefixToLabel: function (book, displayLabel) {
+      return `${this.prefix_field} ${book[this.prefix_field]}: ${displayLabel}`
+    },
+  },
+  data: function () {
     return {
-      bookSearchField: BookSearchField
+      bookSearchField: BookSearchField,
+      prefix_field: 'vid'
     };
-  },};
+  },
+};
 </script>


### PR DESCRIPTION
## Description

Fixing the display label so that the `source by printer` label is correctly displayed - 
![Screenshot 2022-07-27 at 8 52 44 PM](https://user-images.githubusercontent.com/1758326/181285962-c0a240dc-99ff-488b-b823-2a3d3bdd4227.png)

In this image, the `Ratcliffe:...` part is the printer name. Its based on either `pq_printer` if its there, otherwise `colloq_printer`.

The format is `vid <vid value>: <printer-name> <book-title>` as compared to the label for `source by title`, which has the label format `vid <vid value>: <book-title>`.